### PR TITLE
Add IP banning capability

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+
+[0.4.2] - 2015-12-16
+--------------------
+
+Added
+~~~~~
+-  Add IP banning methods in the ConnectionMultiplexer class.
+
 [0.4.1] - 2015-11-05
 --------------------
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with codecs.open(path.join(_HERE, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='txrudp',
-    version='0.4.1',
+    version='0.4.2',
     description='A Twisted extension implementing RUDP',
     long_description=_LONG_DESCRIPTION,
     url='https://github.com/OpenBazaar/txrudp',

--- a/txrudp/rudp.py
+++ b/txrudp/rudp.py
@@ -117,7 +117,7 @@ class ConnectionMultiplexer(
 
     def remove_ip_ban(self, ip_address):
         """
-        Remove and IP address from the ban list.
+        Remove an IP address from the ban list.
 
         Args:
             ip_address: a `String` IP address (without port).

--- a/txrudp/rudp.py
+++ b/txrudp/rudp.py
@@ -48,6 +48,7 @@ class ConnectionMultiplexer(
         self.port = None
         self.relaying = relaying
         self._active_connections = {}
+        self._banned_ips = []
         self._logger = logger
 
     def startProtocol(self):
@@ -103,6 +104,27 @@ class ConnectionMultiplexer(
         """Return iterator over the active contacts."""
         return iter(self._active_connections)
 
+    def ban_ip(self, ip_address):
+        """
+        Add an IP address to the ban list. No connections will be
+        made to this IP and packets will be dropped.
+
+        Args:
+            ip_address: a `String` IP address (without port).
+        """
+        if ip_address not in self._banned_ips:
+            self._banned_ips.append(ip_address)
+
+    def remove_ip_ban(self, ip_address):
+        """
+        Remove and IP address from the ban list.
+
+        Args:
+            ip_address: a `String` IP address (without port).
+        """
+        if ip_address in self._banned_ips:
+            self._banned_ips.remove(ip_address)
+
     def datagramReceived(self, datagram, addr):
         """
         Called when a datagram is received.
@@ -134,6 +156,9 @@ class ConnectionMultiplexer(
                     'Bad packet (invalid RUDP packet): {0}'.format(datagram)
                 )
         else:
+            if (addr[0] in self._banned_ips or
+               rudp_packet.source_addr[0] in self._banned_ips):
+                return
             if rudp_packet.dest_addr[0] != self.public_ip:
                 if self.relaying:
                     self.transport.write(datagram, rudp_packet.dest_addr)


### PR DESCRIPTION
Txrudp already has some basic banning functionality in that you can opt not
to call connection.unregister() after closing a connection and it will ignore
future packets from that connection. However, this only bans a ip/port tuple
and not all ports on a given IP address.

This commit adds the ability to ban just IP addresses. When banned, packets
from that IP address will be dropped and new connections will not be made.

To prevent IP spoofing we need to test the IP address in both the IP packet
header and rudp packet header against the ban list.